### PR TITLE
Grid for floor plan upload

### DIFF
--- a/workspaces/frontend/src/components/FloorPlanPaneSideBar.spec.ts
+++ b/workspaces/frontend/src/components/FloorPlanPaneSideBar.spec.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import type { ImageDimensions } from '../ts/ImageDimensions';
+import { viewport } from '../ts/ViewportSingleton';
+import FloorPlanPaneSideBar from './FloorPlanPaneSideBar.svelte';
+
+describe('FloorPlanPaneSideBar', () => {
+  it('should be initialized', async () => {
+    render(FloorPlanPaneSideBar);
+
+    expect(screen.getByTestId('floorPlanPane')).toBeInTheDocument();
+    expect(screen.getByTestId('floorPlanPane-form')).toBeInTheDocument();
+  });
+
+  describe('initialized with a marker', () => {
+    beforeEach(async () => {
+      viewport.getImageDimensions = vi.fn(() => {
+        return { width: 100, height: 200 } as ImageDimensions;
+      });
+
+      render(FloorPlanPaneSideBar);
+
+      fireEvent(document, new CustomEvent('floorplan', { detail: { action: 'open' } }));
+    });
+
+    it('should display image dimensions', async () => {
+      expect(screen.getByTestId('floorPlanPane-dimensions')).toBeInTheDocument();
+      expect(screen.getByTestId('floorPlanPane-dimensions').textContent).toEqual('100 x 200');
+    });
+  });
+});

--- a/workspaces/frontend/src/components/FloorPlanPaneSideBar.svelte
+++ b/workspaces/frontend/src/components/FloorPlanPaneSideBar.svelte
@@ -17,11 +17,12 @@
   let originalImageDimensions: ImageDimensions;
 
   document.addEventListener('floorplan', (e: CustomEvent) => {
-    if (e.detail['action'] === 'upload') {
+    if (e.detail['action'] === 'open') {
       open = true;
       originalImage = viewport.getImageUrl();
       imageDimensions = viewport.getImageDimensions();
       originalImageDimensions = structuredClone(imageDimensions);
+      viewport.showGrid();
     }
   });
 
@@ -52,6 +53,7 @@
       open = false;
       imageFileInput = undefined;
       files = undefined;
+      viewport.hideGrid();
     }
   };
 
@@ -63,6 +65,7 @@
     imageManipulation.scaleY = 100;
     imageFileInput.value = '';
     await viewport.updateImage(originalImageDimensions, originalImage);
+    viewport.hideGrid();
   };
 </script>
 
@@ -93,7 +96,7 @@
         {#if imageDimensions}
           <p>
             <b>{$_(`location.sidebar.dimensions`)}</b>
-            {imageDimensions.width} x {imageDimensions.height}
+            <span data-testid="floorPlanPane-dimensions">{imageDimensions.width} x {imageDimensions.height}</span>
           </p>
         {/if}
       </div>

--- a/workspaces/frontend/src/components/FloorPlanUploadButton.svelte
+++ b/workspaces/frontend/src/components/FloorPlanUploadButton.svelte
@@ -7,7 +7,7 @@
   let title = $_('location.upload');
 
   const openSidebar = () => {
-    document.dispatchEvent(new CustomEvent('floorplan', { detail: { action: 'upload', imageOverlay: targetImageOverlay } }));
+    document.dispatchEvent(new CustomEvent('floorplan', { detail: { action: 'open', imageOverlay: targetImageOverlay } }));
   };
 </script>
 

--- a/workspaces/frontend/src/mocks/mockViewportSingleton.ts
+++ b/workspaces/frontend/src/mocks/mockViewportSingleton.ts
@@ -1,8 +1,12 @@
 import { beforeEach, vi } from 'vitest';
 import type { LatLng, Layer, Map, PointExpression } from 'leaflet';
-import { point, latLng } from 'leaflet';
+import { point, latLng, Renderer, latLngBounds } from 'leaflet';
 import { setViewport, Viewport } from '../ts/ViewportSingleton';
 import type { ImageDimensions } from '../ts/ImageDimensions';
+
+const mockRenderer = {
+  _removePath: vi.fn(),
+} as any as Renderer;
 
 const mockMap = {
   _targets: vi.fn(),
@@ -13,7 +17,13 @@ const mockMap = {
   layerPointToLatLng: () => latLng(1, 2),
   getZoomScale: () => 2,
   getSize: () => point(10, 10),
+  getBounds: () => latLngBounds([1, 2], [3, 4]),
+  getZoom: () => 1,
+  addLayer: vi.fn(),
   project: () => point(10, 10),
+  on: () => vi.fn(),
+  off: () => vi.fn(),
+  getRenderer: () => mockRenderer,
 } as any as Map;
 
 const _mockViewport = {
@@ -25,6 +35,9 @@ const _mockViewport = {
   getImageDimensions: () => vi.fn(),
 
   updateImage: (_: ImageDimensions, __?: string) => vi.fn(),
+
+  showGrid: vi.fn(),
+  hideGrid: vi.fn(),
 
   reset: vi.fn(),
 

--- a/workspaces/frontend/src/stores/markerTypes.json
+++ b/workspaces/frontend/src/stores/markerTypes.json
@@ -11,8 +11,8 @@
       {
         "name": "table",
         "mapIcon": "square",
-        "mapWidth": 100,
-        "mapHeight": 60
+        "mapWidth": 150,
+        "mapHeight": 80
       }
     ],
     "allowedAttributes": [
@@ -34,8 +34,8 @@
       {
         "name": "person",
         "mapIcon": "person",
-        "mapWidth": 80,
-        "mapHeight": 80
+        "mapWidth": 70,
+        "mapHeight": 70
       }
     ],
     "allowedAttributes": [
@@ -138,38 +138,38 @@
       {
         "name": "unisex",
         "mapIcon": "wc",
-        "mapWidth": 100,
-        "mapHeight": 100
+        "mapWidth": 50,
+        "mapHeight": 50
       },
       {
         "name": "ladies",
         "mapIcon": "woman",
-        "mapWidth": 100,
-        "mapHeight": 100
+        "mapWidth": 50,
+        "mapHeight": 50
       },
       {
         "name": "gentlemens",
         "mapIcon": "man",
-        "mapWidth": 100,
-        "mapHeight": 100
+        "mapWidth": 50,
+        "mapHeight": 50
       },
       {
-        "name": "accessable",
-        "mapIcon": "accessable",
-        "mapWidth": 100,
-        "mapHeight": 100
+        "name": "accessible",
+        "mapIcon": "accessible",
+        "mapWidth": 50,
+        "mapHeight": 50
       },
       {
         "name": "baby",
         "mapIcon": "baby-changing-station",
-        "mapWidth": 100,
-        "mapHeight": 100
+        "mapWidth": 50,
+        "mapHeight": 50
       },
       {
         "name": "bathroom",
         "mapIcon": "bathroom",
-        "mapWidth": 100,
-        "mapHeight": 100
+        "mapWidth": 50,
+        "mapHeight": 50
       }
     ],
     "allowedAttributes": [
@@ -226,44 +226,44 @@
       {
         "name": "other",
         "mapIcon": "widgets",
-        "mapWidth": 50,
-        "mapHeight": 50
+        "mapWidth": 40,
+        "mapHeight": 40
       },
       {
         "name": "printer",
         "mapIcon": "print",
-        "mapWidth": 50,
-        "mapHeight": 50
+        "mapWidth": 40,
+        "mapHeight": 40
       },
       {
         "name": "fridge",
         "mapIcon": "kitchen",
-        "mapWidth": 50,
-        "mapHeight": 70
+        "mapWidth": 40,
+        "mapHeight": 40
       },
       {
         "name": "coffee",
         "mapIcon": "coffee",
-        "mapWidth": 50,
-        "mapHeight": 50
+        "mapWidth": 40,
+        "mapHeight": 40
       },
       {
         "name": "shelf",
         "mapIcon": "shelves",
-        "mapWidth": 50,
-        "mapHeight": 50
+        "mapWidth": 40,
+        "mapHeight": 40
       },
       {
         "name": "water",
         "mapIcon": "water-full",
-        "mapWidth": 50,
-        "mapHeight": 50
+        "mapWidth": 40,
+        "mapHeight": 40
       },
       {
         "name": "play",
         "mapIcon": "videogame-asset",
-        "mapWidth": 50,
-        "mapHeight": 50
+        "mapWidth": 40,
+        "mapHeight": 40
       }
     ],
     "allowedAttributes": [

--- a/workspaces/frontend/src/ts/Grid.spec.ts
+++ b/workspaces/frontend/src/ts/Grid.spec.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { viewport } from './ViewportSingleton';
+import { Grid } from './Grid';
+
+describe('Grid', () => {
+  const defaultSpacing = 10;
+  const showOriginLabel = false;
+  const redrawEvent = 'moveend resize';
+  const hidden = false;
+  const zoomSpacing = [
+    { startZoomLevel: -3, endZoomLevel: -2, spacing: 200 },
+    { startZoomLevel: -1, endZoomLevel: 0, spacing: 100 },
+    { startZoomLevel: 0, endZoomLevel: 4, spacing: 50 },
+  ];
+  let grid;
+
+  beforeEach(async () => {
+    grid = new Grid({
+      labelSteps: defaultSpacing,
+      showOriginLabel: showOriginLabel,
+      redrawEvent: redrawEvent,
+      hidden: hidden,
+      zoomSpacing: zoomSpacing,
+    });
+    grid.onAdd(viewport.getLeafletMap());
+  });
+
+  it('should be initialized with default values', () => {
+    const defaultGrid = new Grid();
+    defaultGrid.onAdd(viewport.getLeafletMap());
+
+    expect(defaultGrid.options.labelSteps).toBe(100);
+    expect(defaultGrid.options.showOriginLabel).toBe(true);
+    expect(defaultGrid.options.redrawEvent).toBe('moveend');
+    expect(defaultGrid.options.hidden).toBe(false);
+    expect(defaultGrid.options.zoomSpacing).toEqual([]);
+  });
+
+  it('should show a hidden grid', () => {
+    const hiddenGrid = new Grid({
+      hidden: true,
+      zoomSpacing: zoomSpacing,
+    });
+    hiddenGrid.onAdd(viewport.getLeafletMap());
+
+    expect(hiddenGrid.options.hidden).toBe(true);
+
+    hiddenGrid.show();
+
+    expect(hiddenGrid.options.hidden).toBe(false);
+  });
+
+  it('should hide a visible grid', () => {
+    const visibleGrid = new Grid({
+      hidden: false,
+      zoomSpacing: zoomSpacing,
+    });
+    visibleGrid.onAdd(viewport.getLeafletMap());
+
+    expect(visibleGrid.options.hidden).toBe(false);
+
+    visibleGrid.hide();
+
+    expect(visibleGrid.options.hidden).toBe(true);
+  });
+});

--- a/workspaces/frontend/src/ts/Grid.ts
+++ b/workspaces/frontend/src/ts/Grid.ts
@@ -1,0 +1,181 @@
+import { divIcon, LatLng, LatLngBounds, LayerGroup, Map, marker, Polyline, Util } from 'leaflet';
+import type { LayerOptions, PolylineOptions } from 'leaflet';
+
+export interface GridZoomSpacing {
+  startZoomLevel: number;
+  endZoomLevel: number;
+  spacing: number;
+}
+
+export interface GridOptions extends LayerOptions {
+  defaultSpacing?: number;
+  labelSteps?: number;
+  showOriginLabel?: boolean;
+  redrawEvent?: string;
+  hidden?: boolean;
+  zoomSpacing: GridZoomSpacing[];
+}
+
+/**
+ * From https://github.com/ablakey/Leaflet.SimpleGraticule
+ * Under BSD 2 license
+ */
+export class Grid extends LayerGroup {
+  private _bounds: LatLngBounds;
+  private _currentSpacing: number;
+
+  options: GridOptions = {
+    defaultSpacing: 100,
+    labelSteps: 100,
+    showOriginLabel: true,
+    redrawEvent: 'moveend',
+    hidden: false,
+    zoomSpacing: [],
+  };
+
+  lineStyle: PolylineOptions = {
+    interactive: false,
+    className: 'stroke-grey/50 stroke-1',
+  };
+
+  constructor(options?: GridOptions) {
+    super([], options);
+    Util.setOptions(this, options);
+  }
+
+  onAdd(map: Map): this {
+    this._map = map;
+
+    // const graticule = this.redraw();
+    this._map.on('viewreset ' + this.options.redrawEvent, this.redraw, this);
+
+    this.eachLayer(map.addLayer, map);
+
+    return this;
+  }
+
+  onRemove(map: Map): this {
+    this._map.off('viewreset ' + this.options.redrawEvent, this.redraw, this);
+    this.eachLayer(this.removeLayer, this);
+
+    return this;
+  }
+
+  hide(): void {
+    this.options.hidden = true;
+    this.redraw();
+  }
+
+  show(): void {
+    this.options.hidden = false;
+    this.redraw();
+  }
+
+  redraw(): void {
+    this._bounds = this._map.getBounds().pad(0.5);
+    this._currentSpacing = this.options.defaultSpacing;
+
+    this.clearLayers();
+
+    if (!this.options.hidden) {
+      const currentZoom = this._map.getZoom();
+
+      for (let i = 0; i < this.options.zoomSpacing.length; i++) {
+        if (currentZoom >= this.options.zoomSpacing[i].startZoomLevel && currentZoom <= this.options.zoomSpacing[i].endZoomLevel) {
+          this._currentSpacing = this.options.zoomSpacing[i].spacing;
+          break;
+        }
+      }
+
+      this.constructLines(this.getMins(), this.getLineCounts());
+
+      if (this.options.showOriginLabel) {
+        this.addLayer(this.addOriginLabel());
+      }
+    }
+  }
+
+  getLineCounts() {
+    return {
+      x: Math.ceil((this._bounds.getEast() - this._bounds.getWest()) / this._currentSpacing),
+      y: Math.ceil((this._bounds.getNorth() - this._bounds.getSouth()) / this._currentSpacing),
+    };
+  }
+
+  getMins() {
+    //rounds up to nearest multiple of x
+    const s = this._currentSpacing;
+    return {
+      x: Math.floor(this._bounds.getWest() / s) * s,
+      y: Math.floor(this._bounds.getSouth() / s) * s,
+    };
+  }
+
+  constructLines(mins, counts) {
+    const lines = new Array(counts.x + counts.y);
+    const labels = new Array(counts.x + counts.y);
+
+    let i = 0;
+    for (i; i <= counts.x; i++) {
+      const x = mins.x + i * this._currentSpacing;
+      lines[i] = this.buildVerticalLine(x);
+      labels[i] = this.buildLabel('gridlabel-horiz', x, x / this.options.labelSteps);
+    }
+
+    //for vertical lines
+    for (let j = 0; j <= counts.y; j++) {
+      const y = mins.y + j * this._currentSpacing;
+      lines[j + i] = this.buildHorizontalLine(y);
+      labels[j + i] = this.buildLabel('gridlabel-vert', y, y / this.options.labelSteps);
+    }
+
+    lines.forEach(this.addLayer, this);
+    labels.forEach(this.addLayer, this);
+  }
+
+  buildVerticalLine(x) {
+    const bottomLL = new LatLng(this._bounds.getSouth(), x);
+    const topLL = new LatLng(this._bounds.getNorth(), x);
+
+    return new Polyline([bottomLL, topLL], this.lineStyle);
+  }
+
+  buildHorizontalLine(y) {
+    const leftLL = new LatLng(y, this._bounds.getWest());
+    const rightLL = new LatLng(y, this._bounds.getEast());
+
+    return new Polyline([leftLL, rightLL], this.lineStyle);
+  }
+
+  buildLabel(axis, position, label) {
+    const bounds = this._map.getBounds().pad(-0.003);
+    let latLng;
+    let classNames = '';
+    if (axis === 'gridlabel-horiz') {
+      latLng = new LatLng(bounds.getNorth(), position);
+    } else {
+      latLng = new LatLng(position, bounds.getWest());
+      classNames = 'rotate-90';
+    }
+
+    return marker(latLng, {
+      interactive: false,
+      icon: divIcon({
+        iconSize: [0, 0],
+        className: 'pl-1 text-sm',
+        html: '<div class="' + axis + ' ' + classNames + '">' + label + '</div>',
+      }),
+    });
+  }
+
+  addOriginLabel() {
+    return marker([0, 0], {
+      interactive: false,
+      icon: divIcon({
+        iconSize: [0, 0],
+        className: 'leaflet-grid-label',
+        html: '<div class="gridlabel-horiz">(0,0)</div>',
+      }),
+    });
+  }
+}

--- a/workspaces/frontend/src/ts/MarkerOverlay.ts
+++ b/workspaces/frontend/src/ts/MarkerOverlay.ts
@@ -279,7 +279,7 @@ export class MarkerOverlay extends L.Layer {
       this._map.latLngToLayerPoint(this._latLngBounds.getNorthWest()),
       this._map.latLngToLayerPoint(this._latLngBounds.getSouthEast())
     );
-    const size = bounds.getSize();
+    const size = bounds.getSize().multiplyBy(1.3); // multiply to compensate inner svg offsets
 
     this.__setPosition(container, bounds.min);
 


### PR DESCRIPTION
## Description

A grid is initialized together with the map itself, but hidden. When opening the floor plan upload dialog, the grid becomes visible and will be hidden once the dialog closes.

I also had to adjust the icon dimensions to keep the sizes realistic. Since all icon SVGs have some offset in their path definitions, I tried to work around this with expanding the icon in the map (x1.3)

![image](https://github.com/AOEpeople/desk-compass/assets/3407199/e51fb093-1274-45e2-97e6-9260473008f9)

Implements: #14 

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing guide](https://github.com/AOEpeople/desk-compass/blob/main/CONTRIBUTING.md)
- [x] Include a description of the changes made in the PR description and in the commit messages.
- [x] Include screenshots/videos of the changes made.
- [x] Ensure your changes are covered by tests and verify that the linter and tests are passing, with `yarn lint` and `yarn test`.
