### PR TITLE
fix: focus marker only once map is completely initialized

### DIFF
--- a/workspaces/frontend/src/components/Screen.svelte
+++ b/workspaces/frontend/src/components/Screen.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
   import * as L from 'leaflet';
-  import { onMount } from 'svelte';
   import { get } from 'svelte/store';
-  import { mapAction, viewport } from '../ts/ViewportSingleton';
+  import { mapAction, viewport, viewportInitialized } from '../ts/ViewportSingleton';
   import InfoPane from './InfoPaneSideBar.svelte';
   import Navigation from './NavigationSideBar.svelte';
   import { markerStore } from '../stores/markers';
@@ -10,9 +9,9 @@
 
   export let params = {};
 
-  onMount(async () => {
+  $: if ($viewportInitialized) {
     if (params['markerId']) {
-      const result = get(markerStore).find((m) => m.id === parseInt(params['markerId']));
+      const result = get(markerStore).find((m) => m.id === params['markerId']);
       if (result) {
         document.dispatchEvent(new CustomEvent('marker', { detail: { action: 'select', marker: result } }));
         viewport.flyTo([result.lat, result.lng], 0);
@@ -21,7 +20,7 @@
     if (params['lat'] && params['lng'] && params['zoom']) {
       viewport.flyTo(L.latLng(params['lat'], params['lng']), parseInt(params['zoom']));
     }
-  });
+  }
 </script>
 
 <div class="flex flex-col md:flex-row h-screen min-h-screen w-full max-w-full">

--- a/workspaces/frontend/src/ts/ViewportSingleton.spec.ts
+++ b/workspaces/frontend/src/ts/ViewportSingleton.spec.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { waitFor } from '@testing-library/svelte';
 import * as L from 'leaflet';
 import { get } from 'svelte/store';
 import { mapAction, Viewport, viewport, viewportInitialized } from './ViewportSingleton';
@@ -16,14 +18,21 @@ describe('ViewportSingleton', () => {
     expect(get(viewportInitialized)).toBe(false);
   });
 
-  test('viewport should be bindable', () => {
+  test('viewport should be bindable', async () => {
     const dispatchEventSpy = vi.spyOn(document, 'dispatchEvent');
-
     const destroyObj = mapAction(mapElement);
 
     expect(destroyObj).toBeDefined();
     expect(destroyObj.destroy).toBeDefined();
     expect(viewport).toBeDefined();
+
+    await waitFor(() => {
+      if (get(viewportInitialized)) {
+        return true;
+      }
+      throw new Error('Viewport not yet initialized');
+    });
+
     expect(get(viewportInitialized)).toBe(true);
 
     expect(dispatchEventSpy).toHaveBeenNthCalledWith(1, new CustomEvent('map:created'));

--- a/workspaces/frontend/src/ts/ViewportSingleton.ts
+++ b/workspaces/frontend/src/ts/ViewportSingleton.ts
@@ -23,7 +23,6 @@ export const setViewport = (vp: Viewport) => {
 
 export const mapAction = (container): { destroy: () => void } => {
   viewport = Viewport.Instance(container);
-  viewportInitialized.set(true);
 
   const invalidateSizeFn = () => {
     viewport.invalidateSize();
@@ -119,6 +118,7 @@ export class Viewport {
       if (response.ok) {
         response.json().then((dimensions) => {
           this.updateImage(dimensions);
+          viewportInitialized.set(true);
         });
       }
     });


### PR DESCRIPTION
## Description

Loading the floor plan image asynchronously caused displaying full map and this ignored the event of selecting the marker. 
So now the `viewportInitialized` event is delayed till the floor plan image is loaded and only then the routing parameters are interpreted.

Closes #39